### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -88,3 +88,6 @@ prior knowledge or feature engineering.
 
 Code to reproduce the results is available at :
 [https://github.com/CVxTz/rubiks_cube](https://github.com/CVxTz/rubiks_cube)
+
+
+[![Run on Repl.it](https://repl.it/badge/github/CVxTz/rubiks_cube)](https://repl.it/github/CVxTz/rubiks_cube)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).